### PR TITLE
Fix Auth0 audience configuration

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -26,7 +26,7 @@ export default function CallbackPage() {
           // Get the access token from Auth0
           const audience = process.env.NEXT_PUBLIC_AUTH0_AUDIENCE || 
                           process.env.AUTH0_AUDIENCE || 
-                          'https://trendit-api.com';
+                          'https://api.potterlabs.xyz';
           
           const accessToken = await getAccessTokenSilently({
             authorizationParams: {

--- a/src/components/auth/auth0-provider.tsx
+++ b/src/components/auth/auth0-provider.tsx
@@ -35,7 +35,7 @@ export function Auth0ProviderWrapper({ children }: Auth0ProviderWrapperProps) {
       clientId={clientId}
       authorizationParams={{
         redirect_uri: redirectUri,
-        audience: audience || 'https://trendit-api.com',
+        audience: audience || 'https://api.potterlabs.xyz',
         scope: "openid profile email"
       }}
       onRedirectCallback={onRedirectCallback}


### PR DESCRIPTION
Fixes Auth0 audience URLs from trendit-api.com to api.potterlabs.xyz to match production backend API URL. This resolves authentication issues where tokens had wrong audience.