### PR TITLE
Fix Auth0 audience configuration for production API

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useAuthStore } from '@/lib/store/auth';
 import { Loader2 } from 'lucide-react';
+import { getAuth0Audience } from '@/lib/config/auth0';
 
 export default function CallbackPage() {
   const { user, isAuthenticated, isLoading, error, getAccessTokenSilently } = useAuth0();
@@ -24,9 +25,7 @@ export default function CallbackPage() {
       if (isAuthenticated && user) {
         try {
           // Get the access token from Auth0
-          const audience = process.env.NEXT_PUBLIC_AUTH0_AUDIENCE || 
-                          process.env.AUTH0_AUDIENCE || 
-                          'https://trendit-api.com';
+          const audience = getAuth0Audience();
           
           const accessToken = await getAccessTokenSilently({
             authorizationParams: {

--- a/src/components/auth/auth0-provider.tsx
+++ b/src/components/auth/auth0-provider.tsx
@@ -2,6 +2,7 @@
 
 import { Auth0Provider } from '@auth0/auth0-react';
 import { useRouter } from 'next/navigation';
+import { getAuth0Audience } from '@/lib/config/auth0';
 
 interface Auth0ProviderWrapperProps {
   children: React.ReactNode;
@@ -35,7 +36,7 @@ export function Auth0ProviderWrapper({ children }: Auth0ProviderWrapperProps) {
       clientId={clientId}
       authorizationParams={{
         redirect_uri: redirectUri,
-        audience: audience || 'https://trendit-api.com',
+        audience: audience || getAuth0Audience(),
         scope: "openid profile email"
       }}
       onRedirectCallback={onRedirectCallback}

--- a/src/lib/config/auth0.ts
+++ b/src/lib/config/auth0.ts
@@ -1,0 +1,17 @@
+/**
+ * Auth0 configuration helpers
+ */
+
+/**
+ * Get the Auth0 audience URL with proper fallback priority
+ * 1. NEXT_PUBLIC_AUTH0_AUDIENCE (frontend env var)
+ * 2. AUTH0_AUDIENCE (backend env var fallback)
+ * 3. Production API URL (default)
+ */
+export const getAuth0Audience = (): string => {
+  return (
+    process.env.NEXT_PUBLIC_AUTH0_AUDIENCE ||
+    process.env.AUTH0_AUDIENCE ||
+    'https://api.potterlabs.xyz'
+  );
+};


### PR DESCRIPTION
## Problem
Auth0 tokens are being generated with wrong audience URLs (`trendit-api.com`) instead of the production API URL (`api.potterlabs.xyz`). This causes network errors during login flow because the backend rejects tokens with incorrect audience.

## Solution
- Creates shared `getAuth0Audience()` helper to centralize audience configuration
- Fixes audience fallback URLs from `trendit-api.com` → `api.potterlabs.xyz`
- Updates both `auth0-provider.tsx` and `auth/callback/page.tsx`
- Prevents duplication and ensures consistency

## Testing
After merge and deployment:
1. Try Auth0 login at https://reddit.potterlabs.xyz
2. Should successfully redirect to Auth0 and back
3. JWT tokens should have correct `aud: "https://api.potterlabs.xyz"`

## Impact
Fixes the network errors preventing Auth0 authentication from working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized the configuration of the Auth0 audience used during sign-in, ensuring a single, consistent source across the app.
  * Improves reliability across environments by reducing the risk of misconfiguration and mismatched audience values.
  * No changes to the login experience; authentication flow and redirects remain the same.
  * Enhances maintainability and future adaptability of authentication settings without impacting end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->